### PR TITLE
When overriding render functions, pass original as the last argument

### DIFF
--- a/tools/pipelines/pipeline.md-reader.js
+++ b/tools/pipelines/pipeline.md-reader.js
@@ -7,7 +7,18 @@ var _ = require('lodash'),
 
 module.exports = function setupMarkdownReaderPipeline(gulp) {
   function parseMarkdown(options, rendererOverrides) {
-    var renderer = new marked.Renderer();
+    var renderer = new marked.Renderer(),
+        overrideFunctions;
+
+    overrideFunctions = _.mapValues(rendererOverrides, function createOverrideFunction(newRenderFunction, name) {
+      var originalFunction = _.get(renderer, name);
+
+      if (_.isFunction(originalFunction)) {
+        return _.partialRight(newRenderFunction, originalFunction);
+      } else {
+        return newRenderFunction;
+      }
+    });
 
     _.assign(renderer, rendererOverrides);
 

--- a/tools/pipelines/pipeline.md-reader.js
+++ b/tools/pipelines/pipeline.md-reader.js
@@ -14,13 +14,13 @@ module.exports = function setupMarkdownReaderPipeline(gulp) {
       var originalFunction = _.get(renderer, name);
 
       if (_.isFunction(originalFunction)) {
-        return _.partialRight(newRenderFunction, originalFunction);
+        return _.partialRight(newRenderFunction, originalFunction).bind(renderer);
       } else {
         return newRenderFunction;
       }
     });
 
-    _.assign(renderer, rendererOverrides);
+    _.assign(renderer, overrideFunctions);
 
     return through.obj(function transform(file, encoding, callback) {
       var parsedData = frontMatter(file.contents.toString()),


### PR DESCRIPTION
This PR updates how custom render functions are handled in the markdown pipeline. If a custom render function is found to match an existing render function, the custom function will be passed the original render function as its final argument, to facilitate better inheritance.