### PR TITLE
Updates readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # web-tools-ds
 
-**web-tools-builder-ngtemplates** is a plugin intended for projects using the [Web-tools](https://github.com/imgix/web-tools) build system. This plugin and its pipelines read in data assets in a variety of formats and stores them for use in templates and other outputs.
+**web-tools-ds** is a plugin intended for projects using the [Web-tools](https://github.com/imgix/web-tools) build system. This plugin and its pipelines read in data assets in a variety of formats and stores them for use in templates and other outputs.


### PR DESCRIPTION
The plugin is named 'web-tools-ds' not 'ng-templates' this PR fixes that verbiage.